### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,5 +1,7 @@
 ---
 name: Validate CODEOWNERS
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/tem-energy/terraform-aws-ec2-bastion-server/security/code-scanning/1](https://github.com/tem-energy/terraform-aws-ec2-bastion-server/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow or the job. This block should award only the minimum required privileges to the GITHUB_TOKEN. In this case, the action used (`tem-energy/cicd/actions/codeowners-validator@main`) reads the repository contents and validates the `CODEOWNERS` file; it is highly likely that only `contents: read` permission is required. The fix is to place a `permissions:` block immediately after the `name:` (at the workflow root—so it covers all jobs unless a job needs more), specifying:

```yaml
permissions:
  contents: read
```

No new imports or steps are needed. The fix must be implemented in `.github/workflows/validate-codeowners.yml`, after the `name: Validate CODEOWNERS` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
